### PR TITLE
Delete local.properties

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Sun Dec 23 09:29:13 PST 2018
-sdk.dir=C\:\\android-sdk


### PR DESCRIPTION
This PR removes the local.properties file from version control. It shouldn't be checked in to version control and will be recreated on the user's system by Android Studio with the proper values.